### PR TITLE
Add catkin tools to Dockerfile install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,9 @@ RUN apt-get -y update && apt-get install -y \
     ros-melodic-gmapping \
     ros-melodic-navigation \
     ros-melodic-interactive-markers \
-    ros-melodic-turtlebot3-gazebo
+    ros-melodic-turtlebot3-gazebo \
+    ros-melodic-catkin \
+    python-catkin-tools
 RUN mkdir -p /root/catkin_ws/src
 WORKDIR /root/catkin_ws
 RUN /bin/bash -c "source /opt/ros/melodic/setup.bash"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ROS on Mac/Windows
+# Dockerized ROS Noetic
 
 Before following the next two steps, install Docker ([installation instructions for Mac](https://docs.docker.com/docker-for-mac/install/) or [for Windows](https://docs.docker.com/docker-for-windows/install/#system-requirements-for-wsl-2-backend)).
 
@@ -18,7 +18,7 @@ Once the other terminal shows the following type of messages
 
 open another terminal:
 1. Run `docker-compose exec ros bash` (`docker-compose up` has to be running)
-2. Run `source /opt/ros/melodic/setup.bash`
+2. Run `source /opt/ros/noetic/setup.bash`
 3. Run `roslaunch turtlebot3_gazebo turtlebot3_world.launch` and you should see a number of messages, including `[ INFO] [1617035063.438483400, 0.126000000]: DiffDrive(ns = //): Advertise odom on odom `
 
 To see whether it was successful, 


### PR DESCRIPTION
Professor Li, 

I've found myself installing the `catkin` tools repeatedly while using the containerized `vnc-ros` VM, and thought it may be useful to include them in the base build. This PR is definitely a suggestion, thank you!

My Best,
Ari